### PR TITLE
Add playground UI and deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: CI and Deploy
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "postbuild": "node scripts/copy-public.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Typescala Playground</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Typescala Playground</h1>
+      <p>Write Typescala scripts and run them instantly in your browser.</p>
+    </header>
+    <main class="app-main">
+      <section class="editor-card">
+        <label class="field">
+          <span class="field-label">Source code</span>
+          <textarea id="source" class="code-input" spellcheck="false"></textarea>
+        </label>
+        <div class="controls">
+          <button id="run" class="primary-button" type="button">Run script</button>
+          <button id="reset" class="ghost-button" type="button">Reset</button>
+        </div>
+      </section>
+      <section class="output-card">
+        <h2>Output</h2>
+        <pre id="output" class="output" aria-live="polite"></pre>
+      </section>
+    </main>
+    <footer class="app-footer">
+      <p>
+        Built with the <a href="https://github.com/" target="_blank" rel="noreferrer">Typescala</a> interpreter.
+      </p>
+    </footer>
+    <script type="module" src="./ui/app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,139 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  background-image: linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.95));
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header,
+.app-footer {
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  text-align: center;
+}
+
+.app-header h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+.app-header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.app-main {
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: clamp(1rem, 4vw, 3rem);
+  max-width: 960px;
+  width: min(100%, 960px);
+  margin: 0 auto;
+}
+
+@media (min-width: 800px) {
+  .app-main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
+.editor-card,
+.output-card {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(12px);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.field-label {
+  font-weight: 600;
+}
+
+.code-input {
+  min-height: 280px;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.8);
+  color: inherit;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', monospace;
+  font-size: 0.95rem;
+  resize: vertical;
+}
+
+.controls {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primary-button,
+.ghost-button {
+  font-size: 1rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.3);
+}
+
+.primary-button:active {
+  transform: translateY(1px);
+}
+
+.ghost-button {
+  background: transparent;
+  color: rgba(226, 232, 240, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.output-card h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.output {
+  min-height: 180px;
+  margin: 0;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.75);
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.app-footer a {
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+.app-footer a:hover {
+  text-decoration: underline;
+}

--- a/scripts/copy-public.mjs
+++ b/scripts/copy-public.mjs
@@ -1,0 +1,20 @@
+import { cp, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const publicDir = join(process.cwd(), 'public');
+const distDir = join(process.cwd(), 'dist');
+
+async function main() {
+  if (!existsSync(publicDir)) {
+    return;
+  }
+
+  await mkdir(distDir, { recursive: true });
+  await cp(publicDir, distDir, { recursive: true });
+}
+
+main().catch(error => {
+  console.error('Failed to copy public assets:', error);
+  process.exitCode = 1;
+});

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1,0 +1,84 @@
+import { evaluateSource } from '../index.js';
+import { formatError, formatResult, getDefaultSnippet } from './presentation.js';
+
+type UIElements = {
+  source: HTMLTextAreaElement;
+  output: HTMLElement;
+  runButton: HTMLButtonElement;
+  resetButton: HTMLButtonElement;
+};
+
+function getElements(): UIElements {
+  const source = document.getElementById('source');
+  const output = document.getElementById('output');
+  const runButton = document.getElementById('run');
+  const resetButton = document.getElementById('reset');
+
+  if (!(source instanceof HTMLTextAreaElement)) {
+    throw new Error('Source textarea not found');
+  }
+
+  if (!(output instanceof HTMLElement)) {
+    throw new Error('Output element not found');
+  }
+
+  if (!(runButton instanceof HTMLButtonElement)) {
+    throw new Error('Run button not found');
+  }
+
+  if (!(resetButton instanceof HTMLButtonElement)) {
+    throw new Error('Reset button not found');
+  }
+
+  return { source, output, runButton, resetButton };
+}
+
+function updateOutput(container: HTMLElement, text: string) {
+  container.textContent = text;
+}
+
+function runScript({ source, output, runButton }: UIElements) {
+  const code = source.value.trim();
+  if (!code) {
+    updateOutput(output, 'Write some Typescala code to get started.');
+    return;
+  }
+
+  runButton.disabled = true;
+  runButton.textContent = 'Running…';
+
+  try {
+    const result = evaluateSource(code);
+    updateOutput(output, formatResult(result));
+  } catch (error) {
+    updateOutput(output, formatError(error));
+  } finally {
+    runButton.disabled = false;
+    runButton.textContent = 'Run script';
+  }
+}
+
+function resetEditor({ source, output }: UIElements) {
+  source.value = getDefaultSnippet();
+  updateOutput(output, 'Ready to run.');
+}
+
+function init() {
+  const elements = getElements();
+  resetEditor(elements);
+
+  elements.runButton.addEventListener('click', () => runScript(elements));
+  elements.resetButton.addEventListener('click', () => resetEditor(elements));
+
+  elements.source.addEventListener('keydown', event => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      const { selectionStart, selectionEnd, value } = elements.source;
+      elements.source.value = `${value.slice(0, selectionStart)}  ${value.slice(selectionEnd)}`;
+      const cursor = selectionStart + 2;
+      elements.source.setSelectionRange(cursor, cursor);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/src/ui/presentation.ts
+++ b/src/ui/presentation.ts
@@ -1,0 +1,27 @@
+import type { Value } from '../values.js';
+
+export function formatResult(value: Value): string {
+  if (typeof value === 'object' && value !== null && 'toString' in value) {
+    try {
+      return String(value.toString());
+    } catch (error) {
+      return `Result: ${JSON.stringify(value)}`;
+    }
+  }
+
+  return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+}
+
+export function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return `Error: ${error.message}`;
+  }
+
+  return `Error: ${String(error)}`;
+}
+
+export function getDefaultSnippet(): string {
+  return `let fib = n => if (n <= 1) n else fib(n - 1) + fib(n - 2);
+
+fib(6)`;
+}

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatError, formatResult, getDefaultSnippet } from '../src/ui/presentation.js';
+import type { Value } from '../src/values.js';
+
+class FakeValue {
+  constructor(private readonly value: string) {}
+
+  toString() {
+    return this.value;
+  }
+}
+
+describe('presentation helpers', () => {
+  it('formats primitive results', () => {
+    expect(formatResult(42)).toBe('42');
+    expect(formatResult('hello')).toBe('hello');
+  });
+
+  it('formats objects using toString when available', () => {
+    const value = new FakeValue('custom');
+    expect(formatResult(value as unknown as Value)).toBe('custom');
+  });
+
+  it('formats errors gracefully', () => {
+    expect(formatError(new Error('Boom'))).toBe('Error: Boom');
+    expect(formatError('bad')).toBe('Error: bad');
+  });
+
+  it('provides a default snippet that is never empty', () => {
+    expect(getDefaultSnippet().length).toBeGreaterThan(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
@@ -11,6 +12,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- build a responsive browser playground for executing Typescala programs
- add presentation helpers and unit tests for formatting UI results
- copy public assets during builds and deploy the site to GitHub Pages on pushes to master

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e513cbb6c8832eaf6146a3157c1dff