### PR TITLE
Fix GitHub Pages workflow branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI and Deploy
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - run: npm test
 
   deploy:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- update the deployment workflow to run on pushes to the main branch
- ensure the deploy job only runs when main is the ref

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e517ded234832e87b7a419882e3177