### PR TITLE
Fix default playground snippet syntax

### DIFF
--- a/src/ui/presentation.ts
+++ b/src/ui/presentation.ts
@@ -21,7 +21,13 @@ export function formatError(error: unknown): string {
 }
 
 export function getDefaultSnippet(): string {
-  return `let fib = n => if (n <= 1) n else fib(n - 1) + fib(n - 2);
+  return `let fib = (n) => {
+  if (n <= 1) {
+    n
+  } else {
+    fib(n - 1) + fib(n - 2)
+  }
+};
 
-fib(6)`;
+fib(6);`;
 }


### PR DESCRIPTION
## Summary
- update the default playground snippet to use valid Typescala syntax for the Fibonacci example

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e522f09d94832e8b508be27b8e2997