### PR TITLE
Support punctuation operators and inline if branches

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -218,12 +218,32 @@ function createGlobalEnvironment(): Environment {
 
   registerMethod(
     'number',
+    'lessThanOrEqual',
+    new NativeFunctionValue(([other], self) => {
+      const left = expectNumber(self!, 'lessThanOrEqual expects a number as the receiver');
+      const right = expectNumber(other ?? NULL_VALUE, 'lessThanOrEqual expects a number argument');
+      return makeBoolean(left <= right);
+    }, 'lessThanOrEqual'),
+  );
+
+  registerMethod(
+    'number',
     'greaterThan',
     new NativeFunctionValue(([other], self) => {
       const left = expectNumber(self!, 'greaterThan expects a number as the receiver');
       const right = expectNumber(other ?? NULL_VALUE, 'greaterThan expects a number argument');
       return makeBoolean(left > right);
     }, 'greaterThan'),
+  );
+
+  registerMethod(
+    'number',
+    'greaterThanOrEqual',
+    new NativeFunctionValue(([other], self) => {
+      const left = expectNumber(self!, 'greaterThanOrEqual expects a number as the receiver');
+      const right = expectNumber(other ?? NULL_VALUE, 'greaterThanOrEqual expects a number argument');
+      return makeBoolean(left >= right);
+    }, 'greaterThanOrEqual'),
   );
 
   registerMethod(

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -62,6 +62,59 @@ export function tokenize(source: string): Token[] {
       continue;
     }
 
+    if (char === '+') {
+      advance();
+      pushToken('identifier', 'plus');
+      continue;
+    }
+
+    if (char === '-') {
+      advance();
+      pushToken('identifier', 'minus');
+      continue;
+    }
+
+    if (char === '*') {
+      advance();
+      pushToken('identifier', 'times');
+      continue;
+    }
+
+    if (char === '/') {
+      advance();
+      pushToken('identifier', 'dividedBy');
+      continue;
+    }
+
+    if (char === '<') {
+      advance();
+      if (peek() === '=') {
+        advance();
+        pushToken('identifier', 'lessThanOrEqual');
+      } else {
+        pushToken('identifier', 'lessThan');
+      }
+      continue;
+    }
+
+    if (char === '>') {
+      advance();
+      if (peek() === '=') {
+        advance();
+        pushToken('identifier', 'greaterThanOrEqual');
+      } else {
+        pushToken('identifier', 'greaterThan');
+      }
+      continue;
+    }
+
+    if (char === '=' && peekNext() === '=') {
+      advance();
+      advance();
+      pushToken('identifier', 'equals');
+      continue;
+    }
+
     if (char === '"') {
       advance();
       let value = '';

--- a/tests/interpreter.test.ts
+++ b/tests/interpreter.test.ts
@@ -10,6 +10,13 @@ describe('Typescala interpreter', () => {
     return value.value;
   };
 
+  const asBoolean = (value: Value): boolean => {
+    if (value.kind !== 'boolean') {
+      throw new Error(`Expected boolean but received ${value.kind}`);
+    }
+    return value.value;
+  };
+
   it('evaluates infix operator calls as method invocations', () => {
     const result = evaluateSource(`
       let total = 1 plus 2
@@ -57,5 +64,40 @@ describe('Typescala interpreter', () => {
     `);
 
     expect(asNumber(result)).toBe(11);
+  });
+
+  it('supports inline if expressions without braces', () => {
+    const result = evaluateSource(`
+      if (1 <= 2) 42 else 0
+    `);
+
+    expect(asNumber(result)).toBe(42);
+  });
+
+  it('evaluates punctuation subtraction operator', () => {
+    const result = evaluateSource(`
+      10 - 3
+    `);
+
+    expect(asNumber(result)).toBe(7);
+  });
+
+  it('evaluates less-than-or-equal comparisons with punctuation syntax', () => {
+    const result = evaluateSource(`
+      2 <= 2
+    `);
+
+    expect(asBoolean(result)).toBe(true);
+  });
+
+  it('evaluates the fibonacci script end-to-end', () => {
+    const result = evaluateSource(`
+      let fib = (n) =>
+        if (n <= 1) n else fib(n - 1) + fib(n - 2)
+
+      fib(6)
+    `);
+
+    expect(asNumber(result)).toBe(8);
   });
 });


### PR DESCRIPTION
## Summary
- add lexer support for punctuation arithmetic and comparison operators
- extend the interpreter with <= and >= number methods and tighten infix parsing
- allow inline if/else branches without braces and cover the fibonacci example with new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e527f390cc832ead22b5d91080d918