### PR TITLE
Improve formatting of interpreter results in UI and fix default snippet

### DIFF
--- a/src/ui/presentation.ts
+++ b/src/ui/presentation.ts
@@ -1,6 +1,30 @@
 import type { Value } from '../values.js';
 
-export function formatResult(value: Value): string {
+function isTypescalaValue(value: unknown): value is Value {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'kind' in value &&
+    typeof (value as { kind?: unknown }).kind === 'string'
+  );
+}
+
+export function formatResult(value: unknown): string {
+  if (isTypescalaValue(value)) {
+    switch (value.kind) {
+      case 'number':
+        return String(value.value);
+      case 'string':
+        return value.value;
+      case 'boolean':
+        return String(value.value);
+      case 'null':
+        return 'null';
+      case 'function':
+        return value.name ? `<function ${value.name}>` : '<function>';
+    }
+  }
+
   if (typeof value === 'object' && value !== null && 'toString' in value) {
     try {
       return String(value.toString());
@@ -27,7 +51,7 @@ export function getDefaultSnippet(): string {
   } else {
     fib(n - 1) + fib(n - 2)
   }
-};
+}
 
-fib(6);`;
+fib(6)`;
 }

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { evaluateSource } from '../src/index.js';
 import { formatError, formatResult, getDefaultSnippet } from '../src/ui/presentation.js';
 import type { Value } from '../src/values.js';
 
@@ -21,12 +22,36 @@ describe('presentation helpers', () => {
     expect(formatResult(value as unknown as Value)).toBe('custom');
   });
 
+  it('formats interpreter values by kind', () => {
+    expect(formatResult({ kind: 'number', value: 7 } as Value)).toBe('7');
+    expect(formatResult({ kind: 'string', value: 'hi' } as Value)).toBe('hi');
+    expect(formatResult({ kind: 'boolean', value: false } as Value)).toBe('false');
+    expect(formatResult({ kind: 'null' } as Value)).toBe('null');
+    expect(
+      formatResult({
+        kind: 'function',
+        call: () => ({ kind: 'null' } as Value),
+        name: 'demo',
+      } as Value),
+    ).toBe('<function demo>');
+    expect(
+      formatResult({
+        kind: 'function',
+        call: () => ({ kind: 'null' } as Value),
+      } as Value),
+    ).toBe('<function>');
+  });
+
   it('formats errors gracefully', () => {
     expect(formatError(new Error('Boom'))).toBe('Error: Boom');
     expect(formatError('bad')).toBe('Error: bad');
   });
 
-  it('provides a default snippet that is never empty', () => {
-    expect(getDefaultSnippet().length).toBeGreaterThan(0);
+  it('provides a default snippet that evaluates successfully', () => {
+    const snippet = getDefaultSnippet();
+    expect(snippet).not.toContain(';');
+
+    const result = evaluateSource(snippet);
+    expect(result).toEqual({ kind: 'number', value: 8 });
   });
 });


### PR DESCRIPTION
## Summary
- format interpreter results in the playground UI based on the Typescala value kind
- keep a fallback for custom objects while adding coverage for the new formatting logic
- update the default playground snippet to omit semicolons and ensure it evaluates successfully

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52f6b7398832ea22a6bd0282df897