### PR TITLE
Add native while loop helper and tests

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -305,6 +305,27 @@ function createGlobalEnvironment(): Environment {
     }, 'print'),
   );
 
+  env.define(
+    'while',
+    new NativeFunctionValue(([condition, block]) => {
+      if (!condition || condition.kind !== 'function') {
+        throw new Error('while expects a function condition');
+      }
+      if (!block || block.kind !== 'function') {
+        throw new Error('while expects a function block');
+      }
+
+      let result: Value = NULL_VALUE;
+      while (true) {
+        const conditionResult = condition.call([]);
+        if (!isTruthy(conditionResult)) {
+          return result;
+        }
+        result = block.call([]);
+      }
+    }, 'while'),
+  );
+
   return env;
 }
 

--- a/tests/interpreter.test.ts
+++ b/tests/interpreter.test.ts
@@ -100,4 +100,53 @@ describe('Typescala interpreter', () => {
 
     expect(asNumber(result)).toBe(8);
   });
+
+  it('repeats a block while the condition function returns truthy', () => {
+    const result = evaluateSource(`
+      let counter = 0
+
+      while(() => counter lessThan 3) {
+        counter = counter plus 1
+      }
+
+      counter
+    `);
+
+    expect(asNumber(result)).toBe(3);
+  });
+
+  it('returns the last value produced by the loop body', () => {
+    const result = evaluateSource(`
+      let counter = 0
+
+      while(() => counter lessThan 3) {
+        counter = counter plus 1
+        counter times 2
+      }
+    `);
+
+    expect(asNumber(result)).toBe(6);
+  });
+
+  it('returns null when the loop body never executes', () => {
+    const result = evaluateSource(`
+      let counter = 10
+
+      while(() => counter lessThan 3) {
+        counter = counter plus 1
+      }
+    `);
+
+    expect(result.kind).toBe('null');
+  });
+
+  it('throws when the condition argument is not a function', () => {
+    expect(() =>
+      evaluateSource(`
+        while(true) {
+          null
+        }
+      `),
+    ).toThrow('while expects a function condition');
+  });
 });


### PR DESCRIPTION
## Summary
- add a native `while` helper to the global environment that repeatedly executes a block while a condition function stays truthy
- validate loop behavior with new interpreter tests covering execution, return values, null result, and invalid arguments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56f469a30832e8ce210a3e0812ce0