### PR TITLE
Add canvas rendering runtime and Mandelbrot tests

### DIFF
--- a/docs/mandelbrot-notes.md
+++ b/docs/mandelbrot-notes.md
@@ -1,0 +1,96 @@
+# Mandelbrot Script Requirements
+
+This document summarizes the pieces of the Typescala runtime that make it
+possible to write a Mandelbrot renderer and how to display the set on the built
+in playground canvas.
+
+## What already exists
+
+The interpreter already exposes the primitives you would use to implement the
+iteration that drives the Mandelbrot calculation:
+
+- Numbers, booleans, strings, functions, and iterators are the only value kinds
+  available to programs. That is enough to store coordinates, counters, and the
+  characters used for ASCII output. 【F:src/values.ts†L1-L34】
+- Numeric arithmetic and comparisons are implemented as method-like infix
+  operators (`plus`, `minus`, `times`, `dividedBy`, etc.), so you can square and
+  combine the real/imaginary parts of `z` and `c` just like in the usual
+  algorithm. 【F:src/interpreter.ts†L205-L268】
+- Control-flow constructs cover both counted loops (`for` with a range iterator)
+  and condition-driven loops via the native `while` helper, which is exactly
+  what the iterative escape-time algorithm needs. 【F:src/parser.ts†L93-L128】【F:src/interpreter.ts†L77-L137】【F:src/interpreter.ts†L305-L339】
+- String concatenation through the `plus` operator and the native `print`
+  function let you build and emit text rows, making a simple ASCII plot
+  achievable already. 【F:src/interpreter.ts†L269-L303】【F:src/interpreter.ts†L318-L339】
+
+With these pieces you can already compute the iteration counts and print a
+character map for the set in the console.
+
+## What is still missing
+
+Typescala now exposes a handful of native helpers for producing pixel output:
+
+- `canvas(width, height)` allocates an opaque bitmap that the interpreter keeps
+  backed by a `Uint8ClampedArray`. 【F:src/runtime.ts†L87-L117】【F:src/interpreter.ts†L343-L353】
+- `canvasWidth(canvas)` and `canvasHeight(canvas)` return the dimensions so that
+  loops can derive their iteration bounds. 【F:src/interpreter.ts†L355-L365】
+- `fillCanvas(canvas, r, g, b, a?)` paints the entire buffer in a single call.
+  【F:src/interpreter.ts†L367-L382】
+- `setPixel(canvas, x, y, r, g, b, a?)` writes an individual pixel after
+  clamping coordinates and channel values. 【F:src/interpreter.ts†L384-L406】
+
+When a script returns a canvas value, the playground renders it inside the
+output panel by copying the pixel buffer into an HTML `<canvas>` element.
+【F:src/ui/app.ts†L32-L71】 This means a Mandelbrot program can focus purely on
+the numerical escape-time algorithm and let the host handle visualization.
+
+The following snippet demonstrates a complete renderer using the built-ins:
+
+```scala
+let width = 60
+let height = 40
+let maxIterations = 40
+
+let image = canvas(width, height)
+
+for py in 0..height {
+  let imaginary = (py / height) * 2.4 - 1.2
+  for px in 0..width {
+    let real = (px / width) * 3.5 - 2.5
+    let zx = 0
+    let zy = 0
+    let iteration = 0
+    let escaped = false
+    let escapeCount = maxIterations
+
+    while(() => iteration < maxIterations, () => {
+      let xSquared = zx * zx
+      let ySquared = zy * zy
+
+      if (xSquared + ySquared > 4) {
+        escaped = true
+        escapeCount = iteration
+        iteration = maxIterations
+      } else {
+        let twoXY = zx * zy * 2
+        let nextX = xSquared - ySquared + real
+        zy = twoXY + imaginary
+        zx = nextX
+        iteration = iteration + 1
+      }
+    })
+
+    if (escaped) {
+      let intensity = (escapeCount / maxIterations) * 255
+      setPixel(image, px, py, intensity, intensity, intensity)
+    } else {
+      setPixel(image, px, py, 0, 0, 0)
+    }
+  }
+}
+
+image
+```
+
+Running this code in the playground will produce a grayscale Mandelbrot set in
+the output region. 【F:tests/mandelbrot.test.ts†L1-L77】

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,6 @@
 import {
   BooleanValue,
+  CanvasValue,
   FunctionValue,
   IteratorStep,
   IteratorValue,
@@ -45,6 +46,7 @@ const methodRegistry: Record<Exclude<ValueKind, 'null'>, Map<string, FunctionVal
   boolean: new Map(),
   function: new Map(),
   iterator: new Map(),
+  canvas: new Map(),
 };
 
 export function registerMethod(
@@ -67,6 +69,8 @@ export function lookupMethod(value: Value, name: string): FunctionValue | undefi
       return methodRegistry.function.get(name);
     case 'iterator':
       return methodRegistry.iterator.get(name);
+    case 'canvas':
+      return methodRegistry.canvas.get(name);
     default:
       return undefined;
   }
@@ -85,6 +89,8 @@ export function isTruthy(value: Value): boolean {
     case 'function':
       return true;
     case 'iterator':
+      return true;
+    case 'canvas':
       return true;
   }
 }
@@ -117,6 +123,8 @@ export function cloneValue(value: Value): Value {
       return value;
     case 'iterator':
       return value;
+    case 'canvas':
+      return value;
   }
 }
 
@@ -129,6 +137,29 @@ export function makeIterator(next: () => IteratorStep): IteratorValue {
 
 export function expectIterator(value: Value, message: string): IteratorValue {
   if (value.kind !== 'iterator') {
+    throw new Error(message);
+  }
+  return value;
+}
+
+export function makeCanvas(width: number, height: number): CanvasValue {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    throw new Error('canvas expects finite width and height');
+  }
+  const w = Math.floor(width);
+  const h = Math.floor(height);
+  if (w <= 0 || h <= 0) {
+    throw new Error('canvas width and height must be positive integers');
+  }
+  const pixels = new Uint8ClampedArray(w * h * 4);
+  for (let index = 0; index < pixels.length; index += 4) {
+    pixels[index + 3] = 255;
+  }
+  return { kind: 'canvas', width: w, height: h, pixels };
+}
+
+export function expectCanvas(value: Value, message: string): CanvasValue {
+  if (value.kind !== 'canvas') {
     throw new Error(message);
   }
   return value;

--- a/src/ui/presentation.ts
+++ b/src/ui/presentation.ts
@@ -25,6 +25,8 @@ export function formatResult(value: unknown): string {
         return value.name ? `<function ${value.name}>` : '<function>';
       case 'iterator':
         return '<iterator>';
+      case 'canvas':
+        return `<canvas ${value.width}×${value.height}>`;
     }
   }
 

--- a/src/ui/snippets.ts
+++ b/src/ui/snippets.ts
@@ -1,11 +1,12 @@
-import type { Value } from '../values.js';
+import type { Value, ValueKind } from '../values.js';
 
 export type DemoScript = {
   id: string;
   label: string;
   description: string;
   code: string;
-  expected: Value;
+  expected?: Value;
+  expectedKind?: ValueKind;
 };
 
 export const demoScripts: readonly DemoScript[] = [
@@ -84,6 +85,55 @@ while(() => counter < 5, () => {
 
 value`,
     expected: { kind: 'number', value: 32 },
+  },
+  {
+    id: 'mandelbrot-canvas',
+    label: 'Mandelbrot Canvas',
+    description: 'Plots the Mandelbrot set into a canvas using the native drawing helpers.',
+    code: `let width = 60
+let height = 40
+let maxIterations = 40
+
+let image = canvas(width, height)
+
+for py in 0..height {
+  let imaginary = (py / height) * 2.4 - 1.2
+  for px in 0..width {
+    let real = (px / width) * 3.5 - 2.5
+    let zx = 0
+    let zy = 0
+    let iteration = 0
+    let escaped = false
+    let escapeCount = maxIterations
+
+    while(() => iteration < maxIterations, () => {
+      let xSquared = zx * zx
+      let ySquared = zy * zy
+
+      if (xSquared + ySquared > 4) {
+        escaped = true
+        escapeCount = iteration
+        iteration = maxIterations
+      } else {
+        let twoXY = zx * zy * 2
+        let nextX = xSquared - ySquared + real
+        zy = twoXY + imaginary
+        zx = nextX
+        iteration = iteration + 1
+      }
+    })
+
+    if (escaped) {
+      let intensity = (escapeCount / maxIterations) * 255
+      setPixel(image, px, py, intensity, intensity, intensity)
+    } else {
+      setPixel(image, px, py, 0, 0, 0)
+    }
+  }
+}
+
+image`,
+    expectedKind: 'canvas',
   },
 ];
 

--- a/src/values.ts
+++ b/src/values.ts
@@ -4,7 +4,8 @@ export type Value =
   | BooleanValue
   | NullValue
   | FunctionValue
-  | IteratorValue;
+  | IteratorValue
+  | CanvasValue;
 
 export type ValueKind = Value['kind'];
 
@@ -41,4 +42,11 @@ export interface IteratorStep {
 export interface IteratorValue {
   kind: 'iterator';
   next(): IteratorStep;
+}
+
+export interface CanvasValue {
+  kind: 'canvas';
+  width: number;
+  height: number;
+  pixels: Uint8ClampedArray;
 }

--- a/tests/canvas.test.ts
+++ b/tests/canvas.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateSource } from '../src/index.js';
+import type { CanvasValue, Value } from '../src/values.js';
+
+const asCanvas = (value: Value): CanvasValue => {
+  if (value.kind !== 'canvas') {
+    throw new Error(`Expected canvas but received ${value.kind}`);
+  }
+  return value;
+};
+
+describe('canvas helpers', () => {
+  it('creates canvases with opaque default pixels', () => {
+    const result = evaluateSource(`
+      let img = canvas(3, 2)
+      img
+    `);
+
+    const canvas = asCanvas(result);
+    expect(canvas.width).toBe(3);
+    expect(canvas.height).toBe(2);
+    expect(canvas.pixels.length).toBe(3 * 2 * 4);
+    for (let index = 3; index < canvas.pixels.length; index += 4) {
+      expect(canvas.pixels[index]).toBe(255);
+    }
+  });
+
+  it('exposes the width and height through helper functions', () => {
+    const result = evaluateSource(`
+      let img = canvas(4, 5)
+      canvasWidth(img) + canvasHeight(img)
+    `);
+
+    expect(result).toEqual({ kind: 'number', value: 9 });
+  });
+
+  it('fills and updates pixels using fillCanvas and setPixel', () => {
+    const result = evaluateSource(`
+      let img = canvas(2, 1)
+      fillCanvas(img, 10, 20, 30, 40)
+      setPixel(img, 1, 0, 90, 80, 70, 60)
+      img
+    `);
+
+    const canvas = asCanvas(result);
+    expect(Array.from(canvas.pixels)).toEqual([10, 20, 30, 40, 90, 80, 70, 60]);
+  });
+
+  it('clamps pixel channel values before writing', () => {
+    const result = evaluateSource(`
+      let img = canvas(1, 1)
+      setPixel(img, 0, 0, 300, 0 - 20, 127.6)
+      img
+    `);
+
+    const canvas = asCanvas(result);
+    expect(Array.from(canvas.pixels)).toEqual([255, 0, 128, 255]);
+  });
+
+  it('throws when setting a pixel out of bounds', () => {
+    expect(() =>
+      evaluateSource(`
+        let img = canvas(2, 2)
+        setPixel(img, 4, 1, 0, 0, 0)
+      `),
+    ).toThrow('setPixel coordinate is out of bounds');
+  });
+
+  it('rejects invalid canvas dimensions', () => {
+    expect(() => evaluateSource('canvas(0, 5)')).toThrow(
+      'canvas width and height must be positive integers',
+    );
+    expect(() => evaluateSource('canvas(10, 0 - 3)')).toThrow(
+      'canvas width and height must be positive integers',
+    );
+  });
+});

--- a/tests/interpreter.test.ts
+++ b/tests/interpreter.test.ts
@@ -97,6 +97,14 @@ describe('Typescala interpreter', () => {
     expect(asBoolean(result)).toBe(true);
   });
 
+  it('compares booleans using the equals operator', () => {
+    const result = evaluateSource(`
+      true equals true
+    `);
+
+    expect(asBoolean(result)).toBe(true);
+  });
+
   it('evaluates the fibonacci script end-to-end', () => {
     const result = evaluateSource(`
       let fib = (n) =>

--- a/tests/mandelbrot.test.ts
+++ b/tests/mandelbrot.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateSource } from '../src/index.js';
+import type { CanvasValue, Value } from '../src/values.js';
+
+const script = `let width = 60
+let height = 40
+let maxIterations = 40
+
+let image = canvas(width, height)
+
+for py in 0..height {
+  let imaginary = (py / height) * 2.4 - 1.2
+  for px in 0..width {
+    let real = (px / width) * 3.5 - 2.5
+    let zx = 0
+    let zy = 0
+    let iteration = 0
+    let escaped = false
+    let escapeCount = maxIterations
+
+    while(() => iteration < maxIterations, () => {
+      let xSquared = zx * zx
+      let ySquared = zy * zy
+
+      if (xSquared + ySquared > 4) {
+        escaped = true
+        escapeCount = iteration
+        iteration = maxIterations
+      } else {
+        let twoXY = zx * zy * 2
+        let nextX = xSquared - ySquared + real
+        zy = twoXY + imaginary
+        zx = nextX
+        iteration = iteration + 1
+      }
+    })
+
+    if (escaped) {
+      let intensity = (escapeCount / maxIterations) * 255
+      setPixel(image, px, py, intensity, intensity, intensity)
+    } else {
+      setPixel(image, px, py, 0, 0, 0)
+    }
+  }
+}
+
+image`;
+
+const toCanvas = (value: Value): CanvasValue => {
+  if (value.kind !== 'canvas') {
+    throw new Error(`Expected canvas but received ${value.kind}`);
+  }
+  return value;
+};
+
+describe('mandelbrot rendering script', () => {
+  it('returns a populated canvas', () => {
+    const result = evaluateSource(script);
+    const canvas = toCanvas(result);
+
+    expect(canvas.width).toBe(60);
+    expect(canvas.height).toBe(40);
+
+    const pixel = (x: number, y: number) => {
+      const index = (y * canvas.width + x) * 4;
+      return canvas.pixels.slice(index, index + 4);
+    };
+
+    const center = pixel(30, 20);
+    expect(Array.from(center)).toEqual([0, 0, 0, 255]);
+
+    const exterior = pixel(55, 6);
+    expect(exterior[0]).toBeGreaterThan(0);
+    expect(exterior[0]).toBeLessThanOrEqual(255);
+    expect(exterior[0]).toBe(exterior[1]);
+    expect(exterior[1]).toBe(exterior[2]);
+  });
+});

--- a/tests/presentation.test.ts
+++ b/tests/presentation.test.ts
@@ -47,6 +47,14 @@ describe('presentation helpers', () => {
         next: () => ({ done: true }),
       } as Value),
     ).toBe('<iterator>');
+    expect(
+      formatResult({
+        kind: 'canvas',
+        width: 2,
+        height: 3,
+        pixels: new Uint8ClampedArray(0),
+      } as Value),
+    ).toBe('<canvas 2×3>');
   });
 
   it('formats errors gracefully', () => {

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -10,7 +10,12 @@ describe('demo scripts', () => {
   for (const script of demoScripts) {
     it(`evaluates the ${script.label} example`, () => {
       const result = evaluateSource(script.code);
-      expect(result).toEqual(script.expected);
+      if (script.expected) {
+        expect(result).toEqual(script.expected);
+      }
+      if (script.expectedKind) {
+        expect(result.kind).toBe(script.expectedKind);
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary
- add native canvas helpers to the runtime and expose boolean equality
- render returned canvas values in the playground UI and ship a Mandelbrot demo script
- document the new drawing APIs and cover them with comprehensive Vitest suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58514c0ec832e9f5ff80987f8c455